### PR TITLE
 fix: prepend space in case of multidomain apps

### DIFF
--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -7,7 +7,7 @@
   register: letsencrypt_cert
 
 - name: Generate certificate
-  shell: "certbot certonly -d {{ domain.split() | join('-d ') }} --email {{ email }} {{ certbot_extra_args }}"
+  shell: "certbot certonly -d {{ domain.split() | join(' -d ') }} --email {{ email }} {{ certbot_extra_args }}"
   become: true
   when: not letsencrypt_cert.stat.exists
 


### PR DESCRIPTION
Prior to this commit, the `certbot certonly` command would have been:

1. **Correct**. `domain: "foo.com"` -> `certbot certonly -d foo.com --email ...` 
1. **Wrong**. `domain: "foo.com bar.com"` -> `certbot certonly -d foo.com-d bar.com --email ...`  resulting in a bad argument error when parsing command.